### PR TITLE
se quito raing_avg del controller getBooksCart

### DIFF
--- a/src/controllers/getBooksCart.js
+++ b/src/controllers/getBooksCart.js
@@ -74,7 +74,6 @@ const getBooksCart = async (req, res, next) => {
             "published_date",
             "price",
             "description",
-            "rating_ave",
             "image",
           ],
           include: [


### PR DESCRIPTION
Se quita el "rating_ave" del carrito que genera conflicto con el modelo book